### PR TITLE
add docker file to deploy easily

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.7.3-alpine3.9
+
+ENV TZ=Asia/Seoul
+VOLUME [/tmp,/app]
+
+RUN apk update \
+        && apk upgrade \
+        && apk add --no-cache bash \
+        bash-doc \
+        bash-completion \
+        && rm -rf /var/cache/apk/* \
+        && /bin/bash
+
+RUN pip3 install oauth2client python-dateutil httplib2 google_auth_oauthlib google-api-python-client pickle-mixin
+
+ENV BROADCAST_ID=""
+
+RUN mkdir /app
+ADD ./ /app/
+
+RUN echo -e '#!/bin/bash \n \
+python bot.py $BROADCAST_ID' > /app/start.sh
+
+
+WORKDIR /app
+ENTRYPOINT ["bash","start.sh"]


### PR DESCRIPTION
I added a docker file, so you can deploy easily. 
1. you should install docker 
2. you should build the image of docker by command 'docker build -t="ddok"'
3. now, you just command ' docker run --env BROADCAST_ID=12311 ddok' in the terminal, you can start a server easily.! happy ending!!